### PR TITLE
Fix problem where update() is called before highlight group is set

### DIFF
--- a/plugin/parenmatch.vim
+++ b/plugin/parenmatch.vim
@@ -16,7 +16,8 @@ set cpo&vim
 augroup parenmatch
   autocmd!
   autocmd VimEnter,ColorScheme * call parenmatch#highlight()
-  autocmd VimEnter,WinEnter,BufEnter,BufWritePost * call parenmatch#update()
+  autocmd VimEnter * execute
+    \ 'autocmd parenmatch WinEnter,BufEnter,BufWritePost * call parenmatch#update()'
   autocmd CursorMoved,CursorMovedI * call parenmatch#cursormoved()
   autocmd InsertEnter * call parenmatch#update(1)
   autocmd InsertLeave * call parenmatch#update(0)


### PR DESCRIPTION
Hi

After https://github.com/itchyny/vim-parenmatch/commit/e1f8d5c40e9823c470da30fd9ac8190d134da16c, the following error occurs when I tried to start my editor by specifying a JSON file.

I use neovim v0.4.3. 

```bash
cat <<EOF > test.json
{
  "foo": "bar"
}
EOF

nvim test.json
```

and neovim raises the following error;

```
Error detected while processing function parenmatch#update:
line   11:
E28: No such highlight group name: ParenMatch
```

`parenmatch#update()` seems to be called by `BufEnter` before `parenmatch#highlight()` .

I changed code to register autocmd for `parenmatch#update()` after VimEnter.