### PR TITLE
fix pollution of v:errmsg

### DIFF
--- a/autoload/parenmatch.vim
+++ b/autoload/parenmatch.vim
@@ -18,7 +18,9 @@ function! parenmatch#update(...) abort
   if !get(b:, 'parenmatch', get(g:, 'parenmatch', 1)) | return | endif
   let i = a:0 ? a:1 : mode() ==# 'i' || mode() ==# 'R'
   let c = matchstr(getline('.'), '.', col('.') - i - 1)
-  silent! call matchdelete(w:parenmatch)
+  if get(w:, 'parenmatch')
+    silent! call matchdelete(w:parenmatch)
+  endif
   if !has_key(s:paren, c) | return | endif
   let [open, closed, flags, stop] = s:paren[c]
   let q = [line('.'), col('.') - i]


### PR DESCRIPTION
Hi itchyny, 

First of all, thanks for your plugin! It has been useful to me because I wanted a way to toggle parenthesis highlighting on a per-buffer basis (which I think is not supported by the standard plugin).

I ended up hitting this edge case with code that I took from another [plugin](https://github.com/vim-scripts/Rename/blob/b240f28d2ede65fa77cd99fe045efe79202f7a34/plugin/Rename.vim#L30-L33).

It seems that your plugin does some invalid calls to matchdelete() that are silenced.
However, `v:errmsg` is still set.

This was affecting the behavior of another plugin that had this code that relied on `v:errmsg`:
```
  let v:errmsg = ''
  silent! execute 'saveas ' . a:name

  if v:errmsg !~# '^$\|^E329'
    echoerr v:errmsg
    return
  endif
```

`v:errmsg` would be `E116: Invalid arguments for function matchdelete`.

I'm not sure if my fix makes sense, let me know what you think.
Thanks.